### PR TITLE
add position_offset parameter;

### DIFF
--- a/ros-allegro/allegro_hand_controllers/src/allegro_node.h
+++ b/ros-allegro/allegro_hand_controllers/src/allegro_node.h
@@ -54,6 +54,8 @@ class AllegroNode: public rclcpp::Node {
 
  protected:
 
+  double position_offset[DOF_JOINTS] = {0.0};
+
   double current_position[DOF_JOINTS] = {0.0};
   double previous_position[DOF_JOINTS] = {0.0};
 
@@ -71,7 +73,7 @@ class AllegroNode: public rclcpp::Node {
   // ROS stuff
   rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_pub;
   rclcpp::Subscription<sensor_msgs::msg::JointState>::SharedPtr joint_cmd_sub;
-
+  OnSetParametersCallbackHandle::SharedPtr param_callback_handle;
   // Store the current and desired joint states.
   sensor_msgs::msg::JointState current_joint_state;
   sensor_msgs::msg::JointState desired_joint_state;


### PR DESCRIPTION
# Setup 
start pd controler on allegro hand
```
colcon build
source install/setup.bash
ros2 run allegro_hand_controllers allegro_node_pd 
ros2 run allegro_hand_controllers freeze_joint.py
```
# Test
Online adjustment (your nodename may be different depending on your launch file remapping)
```
ros2 param set allegro_node_pd position_offset/0 0.49  #finger finger base joint rotate 30 deg
```
You'll see joint moving, but `joint_states` report the same value.
Once these adjustment are confirmed, one can write these into parameter file.

Offline parameter
see [foxglove page](https://foxglove.dev/blog/how-to-use-ros2-parameters) for reference
```
# generate parameter file template with default values
$ ros2 param list > sample.yaml

    position_offset/0: 0.0
    position_offset/1: 0.0
    position_offset/10: 0.0
    position_offset/11: 0.0
    position_offset/12: 0.0
    position_offset/13: 0.0
    position_offset/14: 0.0
    position_offset/15: 0.0
    position_offset/2: 0.0
    position_offset/3: 0.0
    position_offset/4: 0.0
    position_offset/5: 0.0
    position_offset/6: 0.0
    position_offset/7: 0.0
    position_offset/8: 0.0
    position_offset/9: 0.0
# edit the file
# launch with the file applied
$ ros2 run allegro_hand_controllers allegero_node_pd --ros-args --params-file sample.yaml

```