### PR TITLE
Destory rate after polling for joint angles

### DIFF
--- a/ros-allegro/allegro_hand_controllers/allegro_hand_controllers/allegro_robot.py
+++ b/ros-allegro/allegro_hand_controllers/allegro_hand_controllers/allegro_robot.py
@@ -189,6 +189,7 @@ class AllegroRobot(Node):
             rate = self.create_rate(1000)
             while not self._joint_state:
                 rate.sleep()
+            self.destroy_rate(rate)
 
         if self._joint_state:
             return (self._joint_state.position, self._joint_state.effort)


### PR DESCRIPTION
Each time `poll_joint_position` is called, a new `Rate` object is created, which also creates a timer that registers a new callback. Since joint positions are frequently polled it is important to properly destroy the `Rate` object each time, otherwise the callbacks will pile up and cause ros to slow down. 

Before this fix, the publish rate of `allegroHand/joint_cmd` would drop from around 20hz to around 11-12 hz within approximately 10 seconds. Now it maintains a publish rate of 20 hz